### PR TITLE
Remove `role='button'` from links

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-	"useTabs": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+	"useTabs": true
+}

--- a/app/components/dashboard.tsx
+++ b/app/components/dashboard.tsx
@@ -120,14 +120,14 @@ export function DashboardMenuHeader({
 		>
 			<Link
 				to={closeMenuTo}
-				role="button"
 				title="Close Menu"
 				className={cn(
 					"flex items-center justify-center p-2",
 					menuOpen ? "" : hiddenSooner ? "lg:hidden" : "md:hidden"
 				)}
 			>
-				❌
+				<span aria-hidden>❌</span>
+				<span className="sr-only">Close Menu</span>
 			</Link>
 
 			<h1 className="flex-1 py-4 text-lg ml-2">{label}</h1>
@@ -202,14 +202,14 @@ export function ListHeader({
 		<header className="relative flex items-center gap-2 px-2 border-b">
 			<Link
 				to={openMenuTo}
-				role="button"
 				title={"Open Menu"}
 				className={cn(
 					"flex items-center justify-center p-2",
 					hasDetailsSection ? "lg:hidden" : "md:hidden"
 				)}
 			>
-				➡️
+				<span aria-hidden>➡️</span>
+				<span className="sr-only">Open Menu</span>
 			</Link>
 
 			<h1 className="flex-1 py-4 text-lg ml-2">{label}</h1>
@@ -313,11 +313,11 @@ export function DetailsHeader({
 		<header className="relative flex items-center gap-2 px-2 border-b">
 			<Link
 				to=".."
-				role="button"
 				title={"Close Item"}
 				className={cn("flex items-center justify-center p-2", "md:hidden")}
 			>
-				❌
+				<span aria-hidden>❌</span>
+				<span className="sr-only">Close Menu</span>
 			</Link>
 
 			<h1 className="flex-1 py-4 text-lg ml-2">{label}</h1>

--- a/app/components/dashboard.tsx
+++ b/app/components/dashboard.tsx
@@ -313,7 +313,7 @@ export function DetailsHeader({
 		<header className="relative flex items-center gap-2 px-2 border-b">
 			<Link
 				to=".."
-				title={"Close Item"}
+				title={"Close Menu"}
 				className={cn("flex items-center justify-center p-2", "md:hidden")}
 			>
 				<span aria-hidden>❌</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-template",
+  "name": "remix-dashboard-template",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Using `role='button'` on links without a bit of extra effort can cause problems for screen reader users. Keyboard events and focus can be subtly different in various environments. Better to just use a semantic link.

Also: `title` won't be picked up as the label for most screen readers, and its content is not translatable. Went with visually hidden text instead.